### PR TITLE
Added padding and line height to #todiv result text, to make it look better

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -576,4 +576,5 @@ textarea.input100 {
 
 #todiv{
   padding-left: 5px;
+  line-height: 40px;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -574,7 +574,6 @@ textarea.input100 {
   line-height: 1.2;
 }
 
-
-
-
-
+#todiv{
+  padding-left: 5px;
+}


### PR DESCRIPTION
Hi.
Thanks for this wonderful tool. 
#1 - The "Result" text and the converted citation was not aligned, added 5px padding to make it visually aligned with "Result" text.
#2 - Added 40px line-height to make the "after" spacing consistent throughout