### PR TITLE
feat: populating of form fields using url params

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ## URL Params to Autopopulate fields
 
-| param  | Description                                                                             |
-| ------ | --------------------------------------------------------------------------------------- |
-| bibtex | bibtex input. Must be enclosed with quotation marks like: `"` &#124; `'` &#124; `` ` `` |
-| format | Can either be `apa` &#124; `mla` &#124; `chicago` &#124; `harvard` &#124; `vancouver`   |
+| Parameter | Description                                                                             |
+| --------- | --------------------------------------------------------------------------------------- |
+| bibtex    | bibtex input. Must be enclosed with quotation marks like: `"` &#124; `'` &#124; `` ` `` |
+| format    | Can either be `apa` &#124; `mla` &#124; `chicago` &#124; `harvard` &#124; `vancouver`   |
 
 ### Example
 
-`?bibtex="@book{madigan1997brock,
+`https://bibtex.online/?bibtex="@book{madigan1997brock,
 title={Brock biology of microorganisms},
 author={Madigan, Michael T and Martinko, John M and Parker, Jack and others},
 volume={11},

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Bibtex Online Converter
 
+## URL Params to Autopopulate fields
 
+| param  | Description                                                                           |
+| ------ | ------------------------------------------------------------------------------------- |
+| bibtex | bibtex input. Must be enclosed with quotation marks like: `"` &#124; `'` &#124; `     |
+| format | Can either be `apa` &#124; `mla` &#124; `chicago` &#124; `harvard` &#124; `vancouver` |
+
+### Example
+
+`?bibtex="@book{madigan1997brock,
+title={Brock biology of microorganisms},
+author={Madigan, Michael T and Martinko, John M and Parker, Jack and others},
+volume={11},
+year={1997},
+publisher={Prentice hall Upper Saddle River, NJ}
+}"?format=mla`

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## URL Params to Autopopulate fields
 
-| param  | Description                                                                           |
-| ------ | ------------------------------------------------------------------------------------- |
-| bibtex | bibtex input. Must be enclosed with quotation marks like: `"` &#124; `'` &#124; `     |
-| format | Can either be `apa` &#124; `mla` &#124; `chicago` &#124; `harvard` &#124; `vancouver` |
+| param  | Description                                                                             |
+| ------ | --------------------------------------------------------------------------------------- |
+| bibtex | bibtex input. Must be enclosed with quotation marks like: `"` &#124; `'` &#124; `` ` `` |
+| format | Can either be `apa` &#124; `mla` &#124; `chicago` &#124; `harvard` &#124; `vancouver`   |
 
 ### Example
 
@@ -15,4 +15,4 @@ author={Madigan, Michael T and Martinko, John M and Parker, Jack and others},
 volume={11},
 year={1997},
 publisher={Prentice hall Upper Saddle River, NJ}
-}"?format=mla`
+}"&format=mla`

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
 	<script src="js/BibTex.js"></script>
 	<script src="vendor/jquery/jquery-3.2.1.min.js"></script>
 	<script src="js/core.js"></script>
+	<script src="js/populateURLParams.js"></script>
 	<script src="vendor/bootstrap/js/popper.js"></script>
 	<script src="vendor/bootstrap/js/bootstrap.min.js"></script>
 	<script src="vendor/select2/select2.min.js"></script>

--- a/js/populateURLParams.js
+++ b/js/populateURLParams.js
@@ -1,0 +1,62 @@
+const queryString = window.location.search; // ?bibtex="@inproceedings..."
+const urlParams = new URLSearchParams(queryString);
+
+let bibtexStr = urlParams.get("bibtex"); // "@inproceedings...
+let formatStr = urlParams.get("format"); // "chicago"
+
+// Element Refs
+var fromArea = document.getElementById("from");
+var formatJQ = $("#format");
+
+parseUrlParam(bibtexStr, formatStr);
+
+// HELPERS
+function parseUrlParam(bibtexStr, formatStr) {
+  /**
+   * bibtex: string with "",
+   * format?: optional string 'apa' | 'mla' | 'chicago' | 'harvard' | 'vancouver'
+   */
+
+  if (!bibtexStr) return;
+
+  // -- 1. Clean and Validate bibtex ---
+  bibtexStr = bibtexStr.trim();
+
+  // Bibtex must have quotation marks on both ends. Cancel operation if not.
+  if (!hasQuotesOnBothEnds(bibtexStr)) return;
+  bibtexStr = bibtexStr.slice(1, bibtexStr.length - 1); // Remove the quotation marks on both ends
+
+  //   -- 2. Clean and Validate format --
+  if (formatIsValid(formatStr)) formatJQ.val(formatStr).trigger("change");
+
+  //   -- 3. Perform operation --
+  fromArea.value = bibtexStr;
+  convert();
+}
+
+function hasQuotesOnBothEnds(str) {
+  const firstChar = str.charAt(0);
+
+  // If the first character is either ", ', or `
+  if (firstChar === "'" || firstChar === '"' || firstChar === "`") {
+    const lastChar = str.charAt(str.length - 1);
+
+    if (firstChar === lastChar) return true;
+    else return false;
+  }
+
+  return false;
+}
+
+function formatIsValid(str) {
+  if (str) {
+    if (
+      ["apa", "mla", "chicago", "harvard", "vancouver"].includes(
+        str.toLowerCase()
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Hi! First of all, love the project! I was looking for an easy app to convert my Bibtex from my published paper to any format and this one took the cake 🍰! Great work!

## Rationale behind the feature:
I wanted a way to redirect users from the `README.md` in my docs to [bibtex.online](https://bibtex.online) but without the hassle of copying my bibtex, pasting on the site, and then choosing which format.

This way, you can just put `https://bibtex.online/?bibtex="@article{...}"&format=mla` and be greeted with an auto-populated form field! You can then attach it to your docs like so:

### Cite my paper:
```bibtex
@article{ScolioVis,
  author = {Carlo},
  title = {Carlo's Awesome Paper},
  year = {2023},
  journal = {Carlo's Amazing Journal}
}
```
> These are supposedly links in `.md` here

[APA] (https://bibtex.online/?bibtex="@article{...}") 
[MLA] (https://bibtex.online/?bibtex="@article{...}"&format=mla)
[Chicago] (https://bibtex.online/?bibtex="@article{...}"&format=chicago)

## How the URL params work:

| param      | Description |
| ----------- | ----------- |
| bibtex      | bibtex input. Must be enclosed with quotation marks like: `"` &#124; `'`  &#124; ` |
| format   | Can either be `apa` &#124; `mla` &#124; `chicago` &#124; `harvard` &#124; `vancouver` |

### Example:
`?bibtex="@book{madigan1997brock,
title={Brock biology of microorganisms},
author={Madigan, Michael T and Martinko, John M and Parker, Jack and others},
volume={11},
year={1997},
publisher={Prentice hall Upper Saddle River, NJ}
}"?format=apa`

## That's all 😎
Tell me what you think? Hope it gets merged 🤞. Anyways, cool project!